### PR TITLE
[codex] Split stats syllable entrypoint

### DIFF
--- a/.changeset/lightweight-stats-syllables.md
+++ b/.changeset/lightweight-stats-syllables.md
@@ -1,0 +1,6 @@
+---
+"@lunarisapp/stats": major
+"@lunarisapp/readability": patch
+---
+
+Split syllable metrics into `@lunarisapp/stats/syllables` to keep the root stats entrypoint lightweight.

--- a/packages/readability/src/index.ts
+++ b/packages/readability/src/index.ts
@@ -1,5 +1,5 @@
 import type { Language } from "@lunarisapp/language";
-import { TextStats } from "@lunarisapp/stats";
+import { TextStatsSyllables } from "@lunarisapp/stats/syllables";
 import { LRUCache } from "lru-cache";
 import {
   automatedReadabilityIndex,
@@ -33,7 +33,7 @@ export class TextReadability {
   private readonly cache = new LRUCache<string, number>({ max: 512 });
   private readonly cacheEnabled: boolean;
   private lang: Language = "en_US";
-  private textStats!: TextStats;
+  private textStats!: TextStatsSyllables;
 
   constructor(props?: { lang?: Language; cache?: boolean }) {
     const { lang, cache } = props ?? {};
@@ -58,7 +58,7 @@ export class TextReadability {
    */
   setLang(lang: Language) {
     this.lang = lang;
-    this.textStats = new TextStats({ lang });
+    this.textStats = new TextStatsSyllables({ lang });
     this.cache.clear();
   }
 

--- a/packages/stats/README.md
+++ b/packages/stats/README.md
@@ -39,6 +39,11 @@ textStats.wordCount('Hello, world!');
 
 For syllable metrics, import the syllable-aware entrypoint:
 
+> [!NOTE]
+> The syllables module adds around 10 MB of bundle weight because it includes
+> CMU pronunciation data and hyphenation dictionaries. Use the root module when
+> you do not need syllable metrics.
+
 ```typescript
 import { TextStatsSyllables } from '@lunarisapp/stats/syllables';
 

--- a/packages/stats/README.md
+++ b/packages/stats/README.md
@@ -37,6 +37,15 @@ const textStats = new TextStats({
 textStats.wordCount('Hello, world!');
 ```
 
+For syllable metrics, import the syllable-aware entrypoint:
+
+```typescript
+import { TextStatsSyllables } from '@lunarisapp/stats/syllables';
+
+const textStats = new TextStatsSyllables({ lang: 'en_US' });
+textStats.syllableCount('Hello, world!');
+```
+
 | Function                            | Description                                                                 |
 |-------------------------------------|-----------------------------------------------------------------------------|
 | `readingTime(text)`                 | Calculates the reading time of the text in seconds.                         |
@@ -44,16 +53,23 @@ textStats.wordCount('Hello, world!');
 | `sentenceCount(text)`               | Counts the number of sentence in the provided text.                         |
 | `charCount(text)`                   | Counts the number of characters in the provided text.                       |
 | `letterCount(text)`                 | Counts the number of letters in the provided text.                          |
-| `syllableCount(text)`               | Counts the number of syllables in the provided text.                        |
 | `vowelCount(text)`                  | Counts the number of vowels in the provided text.                           |
 | `consonantCount(text)`              | Counts the number of consonants in the provided text.                       |
 | `longWordCount(text, len)`          | Counts the words longer than the specified length in the provided text.     |
 | `shortWordCount(text, len)`         | Counts the words shorter than the specified length in the provided text.    |
+| `avgSentenceLength(text)`           | Calculates the average sentence length in the provided text.                |
+| `avgCharactersPerWord(text)`        | Calculates the average characters per word in the provided text.            |
+
+### Syllable metrics
+
+These methods are available from `TextStatsSyllables` in `@lunarisapp/stats/syllables`.
+
+| Function                            | Description                                                                 |
+|-------------------------------------|-----------------------------------------------------------------------------|
+| `syllableCount(text)`               | Counts the number of syllables in the provided text.                        |
 | `monosyllableCount(text)`           | Counts the monosyllabic words in the provided text.                         |
 | `polysyllableCount(text)`           | Counts the polysyllabic words in the provided text.                         |
-| `avgSentenceLength(text)`           | Calculates the average sentence length in the provided text.                |
 | `avgSyllablesPerWord(text)`         | Calculates the average syllables per word in the provided text.             |
-| `avgCharactersPerWord(text)`        | Calculates the average characters per word in the provided text.            |
 
 ### Other
 ```

--- a/packages/stats/package.json
+++ b/packages/stats/package.json
@@ -31,11 +31,24 @@
     "reading time"
   ],
   "license": "MIT",
+  "sideEffects": false,
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    },
+    "./syllables": {
+      "types": "./dist/syllables.d.ts",
+      "import": "./dist/syllables.mjs",
+      "require": "./dist/syllables.js"
+    }
+  },
   "scripts": {
-    "build": "tsup src/index.ts --format cjs,esm --dts",
+    "build": "tsup",
     "test": "jest"
   },
   "dependencies": {

--- a/packages/stats/src/index.ts
+++ b/packages/stats/src/index.ts
@@ -1,5 +1,3 @@
-import cmudict from "@lunarisapp/cmudict";
-import { TextHyphen } from "@lunarisapp/hyphen";
 import {
   consonants,
   getSentences,
@@ -9,22 +7,20 @@ import {
   vowels,
 } from "@lunarisapp/language";
 import { LRUCache } from "lru-cache";
-import { chunkAndProcessText, lruCache } from "./utils";
+import { lruCache } from "./utils";
 
 // biome-ignore lint/performance/noBarrelFile: library entry point
 export { consonants, type Language, vowels } from "@lunarisapp/language";
 
 export class TextStats {
   private readonly cache = new LRUCache<string, number>({ max: 512 });
-  private lang: Language = "en_US";
-  private readonly cacheEnabled;
-  private cmudict: Record<string, string[][]> | null = null;
-  private hyphen!: TextHyphen;
+  protected lang: Language = "en_US";
+  protected readonly cacheEnabled;
 
   constructor(props?: { lang?: Language; cache?: boolean }) {
     const { lang } = props ?? {};
     this.cacheEnabled = props?.cache ?? true;
-    this.setLang(lang ?? this.lang);
+    this.lang = lang ?? this.lang;
   }
 
   /**
@@ -33,12 +29,6 @@ export class TextStats {
    */
   setLang(lang: Language) {
     this.lang = lang;
-    this.hyphen = new TextHyphen({ lang });
-    if (lang.toLowerCase().startsWith("en")) {
-      this.cmudict = cmudict.dict();
-    } else {
-      this.cmudict = null;
-    }
     this.cache.clear();
   }
 
@@ -110,38 +100,6 @@ export class TextStats {
   }
 
   /**
-   * Count the number of syllables in text.
-   * @param text
-   */
-  syllableCount(text: string) {
-    return chunkAndProcessText(text, (text) =>
-      lruCache(
-        this.cache,
-        "syllableCount",
-        [text],
-        (text) => this.computeSyllableCount(text),
-        this.cacheEnabled
-      )
-    );
-  }
-
-  private computeSyllableCount(text: string) {
-    let count = 0;
-    for (const word of getWords(text)) {
-      try {
-        const pronunciations = this.cmudict?.[word]?.[0];
-        if (!pronunciations) {
-          throw new Error(`Word not found in CMU dictionary: ${word}`);
-        }
-        count += pronunciations.filter((s) => s.match(/\d/g)).length;
-      } catch {
-        count += this.hyphen.positions(word).length + 1;
-      }
-    }
-    return count;
-  }
-
-  /**
    * Count the number of sentences in text.
    * @param text
    */
@@ -182,23 +140,6 @@ export class TextStats {
       return 0;
     }
     return this.wordCount(text) / sentenceCount;
-  }
-
-  /**
-   * Calculate the average number of syllables per word in text.
-   * @param text
-   * @param interval
-   */
-  avgSyllablesPerWord(text: string, interval?: number) {
-    const syllableCount = this.syllableCount(text);
-    const wordCount = this.wordCount(text);
-    if (wordCount === 0) {
-      return 0;
-    }
-    if (interval) {
-      return (syllableCount * interval) / wordCount;
-    }
-    return syllableCount / wordCount;
   }
 
   /**
@@ -247,54 +188,6 @@ export class TextStats {
       return 0;
     }
     return this.wordCount(text) / sentencesCount;
-  }
-
-  /**
-   * Calculates the words in text with 3 or more syllables.
-   * @param text
-   */
-  polysyllableCount(text: string) {
-    return lruCache(
-      this.cache,
-      "polysyllableCount",
-      [text],
-      (text) => this.computePolysyllableCount(text),
-      this.cacheEnabled
-    );
-  }
-
-  private computePolysyllableCount(text: string) {
-    let count = 0;
-    for (const word of getWords(text)) {
-      if (this.computeSyllableCount(word) > 2) {
-        count += 1;
-      }
-    }
-    return count;
-  }
-
-  /**
-   * Calculate the number of monosyllable words in text.
-   * @param text
-   */
-  monosyllableCount(text: string) {
-    return lruCache(
-      this.cache,
-      "monosyllableCount",
-      [text],
-      (text) => this.computeMonosyllableCount(text),
-      this.cacheEnabled
-    );
-  }
-
-  private computeMonosyllableCount(text: string) {
-    let count = 0;
-    for (const word of getWords(text)) {
-      if (this.computeSyllableCount(word) === 1) {
-        count += 1;
-      }
-    }
-    return count;
   }
 
   /**

--- a/packages/stats/src/syllables.ts
+++ b/packages/stats/src/syllables.ts
@@ -1,0 +1,132 @@
+import cmudict from "@lunarisapp/cmudict";
+import { TextHyphen } from "@lunarisapp/hyphen";
+import { getWords, type Language } from "@lunarisapp/language";
+import { LRUCache } from "lru-cache";
+import { TextStats } from ".";
+import { chunkAndProcessText, lruCache } from "./utils";
+
+// biome-ignore lint/performance/noBarrelFile: library entry point
+export type { Language } from "@lunarisapp/language";
+
+export class TextStatsSyllables extends TextStats {
+  private readonly syllableCache = new LRUCache<string, number>({ max: 512 });
+  private cmudict: Record<string, string[][]> | null = null;
+  private hyphen!: TextHyphen;
+
+  constructor(props?: { lang?: Language; cache?: boolean }) {
+    super(props);
+    this.setLang(this.lang);
+  }
+
+  /**
+   * Set the language for syllable-aware text statistics.
+   * @param lang
+   */
+  override setLang(lang: Language) {
+    super.setLang(lang);
+    this.hyphen = new TextHyphen({ lang });
+    if (lang.toLowerCase().startsWith("en")) {
+      this.cmudict = cmudict.dict();
+    } else {
+      this.cmudict = null;
+    }
+    this.syllableCache.clear();
+  }
+
+  /**
+   * Count the number of syllables in text.
+   * @param text
+   */
+  syllableCount(text: string) {
+    return chunkAndProcessText(text, (text) =>
+      lruCache(
+        this.syllableCache,
+        "syllableCount",
+        [text],
+        (text) => this.computeSyllableCount(text),
+        this.cacheEnabled
+      )
+    );
+  }
+
+  private computeSyllableCount(text: string) {
+    let count = 0;
+    for (const word of getWords(text)) {
+      try {
+        const pronunciations = this.cmudict?.[word]?.[0];
+        if (!pronunciations) {
+          throw new Error(`Word not found in CMU dictionary: ${word}`);
+        }
+        count += pronunciations.filter((s) => s.match(/\d/g)).length;
+      } catch {
+        count += this.hyphen.positions(word).length + 1;
+      }
+    }
+    return count;
+  }
+
+  /**
+   * Calculate the average number of syllables per word in text.
+   * @param text
+   * @param interval
+   */
+  avgSyllablesPerWord(text: string, interval?: number) {
+    const syllableCount = this.syllableCount(text);
+    const wordCount = this.wordCount(text);
+    if (wordCount === 0) {
+      return 0;
+    }
+    if (interval) {
+      return (syllableCount * interval) / wordCount;
+    }
+    return syllableCount / wordCount;
+  }
+
+  /**
+   * Calculates the words in text with 3 or more syllables.
+   * @param text
+   */
+  polysyllableCount(text: string) {
+    return lruCache(
+      this.syllableCache,
+      "polysyllableCount",
+      [text],
+      (text) => this.computePolysyllableCount(text),
+      this.cacheEnabled
+    );
+  }
+
+  private computePolysyllableCount(text: string) {
+    let count = 0;
+    for (const word of getWords(text)) {
+      if (this.computeSyllableCount(word) > 2) {
+        count += 1;
+      }
+    }
+    return count;
+  }
+
+  /**
+   * Calculate the number of monosyllable words in text.
+   * @param text
+   */
+  monosyllableCount(text: string) {
+    return lruCache(
+      this.syllableCache,
+      "monosyllableCount",
+      [text],
+      (text) => this.computeMonosyllableCount(text),
+      this.cacheEnabled
+    );
+  }
+
+  private computeMonosyllableCount(text: string) {
+    let count = 0;
+    for (const word of getWords(text)) {
+      if (this.computeSyllableCount(word) === 1) {
+        count += 1;
+      }
+    }
+    return count;
+  }
+}

--- a/packages/stats/tests/stats.test.ts
+++ b/packages/stats/tests/stats.test.ts
@@ -289,7 +289,7 @@ describe("stats tests", () => {
 
   describe("build output", () => {
     it("root ESM does not reference syllable dictionaries", () => {
-      const distPath = join(import.meta.dirname, "../dist/index.mjs");
+      const distPath = join(process.cwd(), "dist/index.mjs");
       if (!existsSync(distPath)) {
         return;
       }

--- a/packages/stats/tests/stats.test.ts
+++ b/packages/stats/tests/stats.test.ts
@@ -1,5 +1,8 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { describe, expect, it } from "@jest/globals";
 import { type Language, TextStats } from "../src";
+import { TextStatsSyllables } from "../src/syllables";
 import {
   emptyStr,
   italianText,
@@ -16,6 +19,7 @@ function assertDelta(actual: number, expected: number, delta = 0.1) {
 
 describe("stats tests", () => {
   const textStats = new TextStats();
+  const syllableStats = new TextStatsSyllables();
   describe("counts", () => {
     it("char count", () => {
       textStats.setLang("en");
@@ -69,35 +73,35 @@ describe("stats tests", () => {
       for (const testCase of testSyllableCountCases) {
         const [lang, text, expected, delta] = testCase;
         it(`syllable count: ${(text as string).slice(0, 10)}${(text as string).length >= 10 ? "..." : ""}`, () => {
-          textStats.setLang(lang as Language);
-          const actual = textStats.syllableCount(text as string);
+          syllableStats.setLang(lang as Language);
+          const actual = syllableStats.syllableCount(text as string);
           assertDelta(actual, expected as number, delta as number);
         });
       }
     });
 
     it("polysyllable count", () => {
-      textStats.setLang("en");
-      const count = textStats.polysyllableCount(longTest);
+      syllableStats.setLang("en");
+      const count = syllableStats.polysyllableCount(longTest);
       expect(count).toBe(38);
     });
 
     it("monosyllable count", () => {
-      textStats.setLang("en");
-      const count = textStats.monosyllableCount(longTest);
+      syllableStats.setLang("en");
+      const count = syllableStats.monosyllableCount(longTest);
       expect(count).toBe(249);
     });
 
     it("polysyllable count single word", () => {
-      textStats.setLang("en");
-      expect(textStats.polysyllableCount("interesting")).toBe(1);
-      expect(textStats.polysyllableCount("dog")).toBe(0);
+      syllableStats.setLang("en");
+      expect(syllableStats.polysyllableCount("interesting")).toBe(1);
+      expect(syllableStats.polysyllableCount("dog")).toBe(0);
     });
 
     it("monosyllable count single word", () => {
-      textStats.setLang("en");
-      expect(textStats.monosyllableCount("dog")).toBe(1);
-      expect(textStats.monosyllableCount("interesting")).toBe(0);
+      syllableStats.setLang("en");
+      expect(syllableStats.monosyllableCount("dog")).toBe(1);
+      expect(syllableStats.monosyllableCount("interesting")).toBe(0);
     });
 
     it("mini word count", () => {
@@ -121,8 +125,8 @@ describe("stats tests", () => {
     });
 
     it("avg syllables per word", () => {
-      textStats.setLang("en");
-      const avg = textStats.avgSyllablesPerWord(longTest);
+      syllableStats.setLang("en");
+      const avg = syllableStats.avgSyllablesPerWord(longTest);
       assertDelta(avg, 1.48, 0.01);
     });
 
@@ -152,7 +156,7 @@ describe("stats tests", () => {
   });
 
   describe("empty text", () => {
-    it("all count methods return 0", () => {
+    it("all lightweight count methods return 0", () => {
       textStats.setLang("en");
       expect(textStats.charCount(emptyStr)).toBe(0);
       expect(textStats.letterCount(emptyStr)).toBe(0);
@@ -160,29 +164,33 @@ describe("stats tests", () => {
       expect(textStats.consonantCount(emptyStr)).toBe(0);
       expect(textStats.wordCount(emptyStr)).toBe(0);
       expect(textStats.sentenceCount(emptyStr)).toBe(0);
-      expect(textStats.syllableCount(emptyStr)).toBe(0);
-      expect(textStats.polysyllableCount(emptyStr)).toBe(0);
-      expect(textStats.monosyllableCount(emptyStr)).toBe(0);
       expect(textStats.miniWordCount(emptyStr)).toBe(0);
       expect(textStats.longWordCount(emptyStr)).toBe(0);
     });
 
-    it("all average methods return 0", () => {
+    it("all lightweight average methods return 0", () => {
       textStats.setLang("en");
       expect(textStats.avgSentenceLength(emptyStr)).toBe(0);
-      expect(textStats.avgSyllablesPerWord(emptyStr)).toBe(0);
       expect(textStats.avgCharactersPerWord(emptyStr)).toBe(0);
       expect(textStats.avgLettersPerWord(emptyStr)).toBe(0);
       expect(textStats.avgSentencesPerWord(emptyStr)).toBe(0);
       expect(textStats.avgWordsPerSentence(emptyStr)).toBe(0);
     });
+
+    it("all syllable methods return 0", () => {
+      syllableStats.setLang("en");
+      expect(syllableStats.syllableCount(emptyStr)).toBe(0);
+      expect(syllableStats.polysyllableCount(emptyStr)).toBe(0);
+      expect(syllableStats.monosyllableCount(emptyStr)).toBe(0);
+      expect(syllableStats.avgSyllablesPerWord(emptyStr)).toBe(0);
+    });
   });
 
   describe("parameter variations", () => {
     it("avg syllables per word with interval", () => {
-      textStats.setLang("en");
-      const base = textStats.avgSyllablesPerWord(longTest);
-      const withInterval = textStats.avgSyllablesPerWord(longTest, 10);
+      syllableStats.setLang("en");
+      const base = syllableStats.avgSyllablesPerWord(longTest);
+      const withInterval = syllableStats.avgSyllablesPerWord(longTest, 10);
       assertDelta(withInterval, base * 10, 0.01);
     });
 
@@ -238,8 +246,8 @@ describe("stats tests", () => {
     });
 
     it("spanish syllable count", () => {
-      textStats.setLang("es");
-      assertDelta(textStats.syllableCount(longSpanishText), 306, 10);
+      syllableStats.setLang("es");
+      assertDelta(syllableStats.syllableCount(longSpanishText), 306, 10);
     });
 
     it("italian counts", () => {
@@ -270,7 +278,41 @@ describe("stats tests", () => {
       noCacheStats.setLang("en");
       expect(noCacheStats.sentenceCount(longTest)).toBe(17);
       expect(noCacheStats.wordCount(longTest)).toBe(372);
+    });
+
+    it("syllable operations work with cache disabled", () => {
+      const noCacheStats = new TextStatsSyllables({ cache: false });
+      noCacheStats.setLang("en");
       assertDelta(noCacheStats.avgSyllablesPerWord(longTest), 1.48, 0.01);
+    });
+  });
+
+  describe("build output", () => {
+    it("root ESM does not reference syllable dictionaries", () => {
+      const distPath = join(import.meta.dirname, "../dist/index.mjs");
+      if (!existsSync(distPath)) {
+        return;
+      }
+      const seen = new Set<string>();
+      const readImportGraph = (path: string): string => {
+        if (seen.has(path)) {
+          return "";
+        }
+        seen.add(path);
+        const source = readFileSync(path, "utf8");
+        const imports = Array.from(
+          source.matchAll(/from\s+["'](\.\/[^"']+)["']/g)
+        ).map((match) => match[1]);
+        return [
+          source,
+          ...imports.map((specifier) =>
+            readImportGraph(join(dirname(path), specifier))
+          ),
+        ].join("\n");
+      };
+      const output = readImportGraph(distPath);
+      expect(output).not.toContain("@lunarisapp/cmudict");
+      expect(output).not.toContain("@lunarisapp/hyphen");
     });
   });
 });

--- a/packages/stats/tsup.config.ts
+++ b/packages/stats/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts", "src/syllables.ts"],
+  format: ["cjs", "esm"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+});


### PR DESCRIPTION
## Summary
- Keep `@lunarisapp/stats` lightweight by moving syllable metrics to `@lunarisapp/stats/syllables`.
- Add `TextStatsSyllables`, package exports, docs, and a major changeset.
- Update readability to consume the syllable-aware entrypoint internally.

## Validation
- `pnpm --filter @lunarisapp/stats build`
- `pnpm --filter @lunarisapp/stats test`
- `pnpm --filter @lunarisapp/readability test`
- `pnpm build`